### PR TITLE
DEV: Upgrade modifyClass syntax to remove object-literal decorators

### DIFF
--- a/javascripts/discourse/initializers/init-alt-vote-cat-style.js
+++ b/javascripts/discourse/initializers/init-alt-vote-cat-style.js
@@ -46,114 +46,120 @@ export default apiInitializer("1.1", (api) => {
   });
 
   withSilencedDeprecations("discourse.hbr-topic-list-overrides", () => {
-    api.modifyClass("component:topic-list-item", {
-      pluginId: "discourse-alternative-voting-category-style",
-      excerptsRouter: service("router"),
-      votesLeft: alias("currentUser.votes_left"),
-      userVoted: alias("topic.user_voted"),
+    api.modifyClass(
+      "component:topic-list-item",
+      (Superclass) =>
+        class extends Superclass {
+          @service("router") excerptsRouter;
+          @alias("currentUser.votes_left") votesLeft;
+          @alias("topic.user_voted") userVoted;
 
-      @discourseComputed("topic")
-      unboundClassNames(topic) {
-        let classList = this._super(...arguments);
-        if (!topic.can_vote) {
-          classList += " non-voting";
-        }
-        return classList;
-      },
-
-      @discourseComputed("excerptsRouter.currentRoute.attributes.category.id")
-      expandPinned(currentCategoryId) {
-        return currentCategoryId &&
-          (settings.include_excerpts || settings.vote_from_topic_list) &&
-          votingCategories.some((c) => c === Number(currentCategoryId))
-          ? true
-          : this._super();
-      },
-      click(e) {
-        const target = e.target;
-        const topic = this.topic;
-        if (
-          target.classList.contains("topic-list-vote-button") &&
-          settings.vote_from_topic_list &&
-          (this.votesLeft > 0 || this.userVoted) &&
-          !topic.closed &&
-          topic.unread !== undefined
-        ) {
-          let voteCountElem = target.nextElementSibling;
-          let voteCount = parseInt(voteCountElem.innerHTML, 10);
-          let voteType;
-
-          if (target.classList.contains("can-vote")) {
-            voteCountElem.innerHTML = voteCount + 1;
-            voteType = "vote";
-
-            this.set("votesLeft", this.votesLeft - 1);
-            this.set("userVoted", true);
-
-            if (this.votesLeft === 0) {
-              document
-                .querySelectorAll(
-                  ".topic-list-item:not(.closed) .topic-list-vote-button.can-vote"
-                )
-                .forEach((voteButton) => {
-                  const tli = voteButton.closest(".topic-list-item");
-                  if (
-                    tli.classList.contains("visited") ||
-                    !tli.classList.contains("unseen-topic")
-                  ) {
-                    voteButton.classList.add("disabled");
-                    voteButton.title = i18n(themePrefix("out_of_votes"));
-                  }
-                });
+          @discourseComputed("topic")
+          unboundClassNames(topic) {
+            let classList = super.unboundClassNames;
+            if (!topic.can_vote) {
+              classList += " non-voting";
             }
-            // Ensure clicked button has proper title and class
-            target.title = i18n(themePrefix("user_vote"));
-            target.classList.remove("disabled");
-          } else {
-            voteCountElem.innerHTML = voteCount - 1;
-            voteType = "unvote";
-
-            this.set("votesLeft", this.votesLeft + 1);
-            this.set("userVoted", false);
-
-            if (this.votesLeft > 0) {
-              document
-                .querySelectorAll(
-                  ".topic-list-item:not(.closed) .topic-list-vote-button.can-vote"
-                )
-                .forEach((voteButton) => {
-                  const tli = voteButton.closest(".topic-list-item");
-                  if (
-                    tli.classList.contains("visited") ||
-                    !tli.classList.contains("unseen-topic")
-                  ) {
-                    voteButton.classList.remove("disabled");
-                    voteButton.title = i18n(themePrefix("user_no_vote"));
-                  }
-                });
-            }
-
-            target.title = i18n(themePrefix("user_no_vote"));
+            return classList;
           }
 
-          target.classList.toggle("can-vote");
+          @discourseComputed(
+            "excerptsRouter.currentRoute.attributes.category.id"
+          )
+          expandPinned(currentCategoryId) {
+            return currentCategoryId &&
+              (settings.include_excerpts || settings.vote_from_topic_list) &&
+              votingCategories.some((c) => c === Number(currentCategoryId))
+              ? true
+              : super.expandPinned();
+          }
 
-          ajax(`/voting/${voteType}`, {
-            type: "POST",
-            data: {
-              topic_id: topic.id,
-            },
-          })
-            .then((result) => {
-              this.currentUser.setProperties({
-                votes_exceeded: !result.can_vote,
-                votes_left: result.votes_left,
-              });
-            })
-            .catch(popupAjaxError);
+          click(e) {
+            const target = e.target;
+            const topic = this.topic;
+            if (
+              target.classList.contains("topic-list-vote-button") &&
+              settings.vote_from_topic_list &&
+              (this.votesLeft > 0 || this.userVoted) &&
+              !topic.closed &&
+              topic.unread !== undefined
+            ) {
+              let voteCountElem = target.nextElementSibling;
+              let voteCount = parseInt(voteCountElem.innerHTML, 10);
+              let voteType;
+
+              if (target.classList.contains("can-vote")) {
+                voteCountElem.innerHTML = voteCount + 1;
+                voteType = "vote";
+
+                this.set("votesLeft", this.votesLeft - 1);
+                this.set("userVoted", true);
+
+                if (this.votesLeft === 0) {
+                  document
+                    .querySelectorAll(
+                      ".topic-list-item:not(.closed) .topic-list-vote-button.can-vote"
+                    )
+                    .forEach((voteButton) => {
+                      const tli = voteButton.closest(".topic-list-item");
+                      if (
+                        tli.classList.contains("visited") ||
+                        !tli.classList.contains("unseen-topic")
+                      ) {
+                        voteButton.classList.add("disabled");
+                        voteButton.title = i18n(themePrefix("out_of_votes"));
+                      }
+                    });
+                }
+                // Ensure clicked button has proper title and class
+                target.title = i18n(themePrefix("user_vote"));
+                target.classList.remove("disabled");
+              } else {
+                voteCountElem.innerHTML = voteCount - 1;
+                voteType = "unvote";
+
+                this.set("votesLeft", this.votesLeft + 1);
+                this.set("userVoted", false);
+
+                if (this.votesLeft > 0) {
+                  document
+                    .querySelectorAll(
+                      ".topic-list-item:not(.closed) .topic-list-vote-button.can-vote"
+                    )
+                    .forEach((voteButton) => {
+                      const tli = voteButton.closest(".topic-list-item");
+                      if (
+                        tli.classList.contains("visited") ||
+                        !tli.classList.contains("unseen-topic")
+                      ) {
+                        voteButton.classList.remove("disabled");
+                        voteButton.title = i18n(themePrefix("user_no_vote"));
+                      }
+                    });
+                }
+
+                target.title = i18n(themePrefix("user_no_vote"));
+              }
+
+              target.classList.toggle("can-vote");
+
+              ajax(`/voting/${voteType}`, {
+                type: "POST",
+                data: {
+                  topic_id: topic.id,
+                },
+              })
+                .then((result) => {
+                  this.currentUser.setProperties({
+                    votes_exceeded: !result.can_vote,
+                    votes_left: result.votes_left,
+                  });
+                })
+                .catch(popupAjaxError);
+            }
+            return super.click(...arguments);
+          }
         }
-        return this._super(...arguments);
-      },
-    });
+    );
   });
 });

--- a/javascripts/discourse/initializers/init-alt-vote-cat-style.js
+++ b/javascripts/discourse/initializers/init-alt-vote-cat-style.js
@@ -71,7 +71,7 @@ export default apiInitializer("1.1", (api) => {
               (settings.include_excerpts || settings.vote_from_topic_list) &&
               votingCategories.some((c) => c === Number(currentCategoryId))
               ? true
-              : super.expandPinned();
+              : super.expandPinned;
           }
 
           click(e) {


### PR DESCRIPTION
Decorators on object literal properties are unsupported in most modern JS tooling, including ts/glint and Prettier 3.0. Using the new native-class-based modifyClass syntax means we can use decorators safely